### PR TITLE
add-media-contact: add media contact info

### DIFF
--- a/src/components/contactPageContent/ContactPageContent.js
+++ b/src/components/contactPageContent/ContactPageContent.js
@@ -1,4 +1,5 @@
 import React from "react"
+import MediaContact from "../mediaContact/MediaContact"
 
 const ContactPageContent = (props) => {
   return (
@@ -22,6 +23,9 @@ const ContactPageContent = (props) => {
             info@allpurpose.io
           </a>
           {/* <a>Learn more -> </a> */}
+          <div className="pt-12">
+            <MediaContact />
+          </div>
         </div>
         <div className="col-md-6">
           <form name="contact" method="POST" data-netlify="true" netlify-honeypot="bot-field">

--- a/src/components/mediaContact/MediaContact.js
+++ b/src/components/mediaContact/MediaContact.js
@@ -1,0 +1,20 @@
+import React from "react"
+
+const MediaContact = ({ showMediaKit }) => {
+
+  return (
+    <React.Fragment>
+      <h3 className="eyebrow mt-16 block">Media Contact</h3>
+      <p>Karli Leitl, Communications Consultant<br />
+      Switchboard Public Relations<br />
+      <a href="mailto:karli@switchboardpr.com">karli@switchboardpr.com</a><br />
+      778-401-6040</p>
+      {showMediaKit ? (
+        <p className="pt-12"><a href="https://drive.google.com/drive/u/1/folders/1K5jO9_g1h8QyvHaBOCG_jQMouyA0XMJS" target="_blank" rel="noopener noreferrer" className="pt-12">View our media kit</a>.</p>
+      ) : null}
+    </React.Fragment>
+  )
+
+}
+
+export default MediaContact

--- a/src/templates/newsPage.js
+++ b/src/templates/newsPage.js
@@ -4,6 +4,7 @@ import Layout from "../components/layout/Layout"
 import PageHeaderGeneral from "../components/pageHeader/PageHeaderGeneral"
 import CallToAction from "../components/callToAction/CallToAction"
 import NewsArticlesExcerpts from "../components/newsArticlesExcerpts/NewsArticlesExcerpts"
+import MediaContact from "../components/mediaContact/MediaContact"
 
 export const pageQuery = graphql`
   query NewsPageQuery {
@@ -70,6 +71,9 @@ const NewsPage = (props) => {
         <div className="container pb-24">
           <hr className="theme-color mb-48 mt-0" />
           <NewsArticlesExcerpts />
+          <div className="pt-24">
+            <MediaContact />
+          </div>
           <hr className="theme-color mt-48 mb-0" />
         </div>
       </div>


### PR DESCRIPTION
This resolves #41 

I have added the Media Contact info to the news page can contact page. I have also allowed for the ability to display a link to our media kit using the prop `showMediaKit`. At the moment, the media kit is not linked, but it will be in the near future.