### PR TITLE
Add remote team photo to Careers page

### DIFF
--- a/src/templates/careersPage.js
+++ b/src/templates/careersPage.js
@@ -50,7 +50,6 @@ export const query = graphql`
             culture_photos {
               photo
             }
-            remote_team
             remote_team_vid {
               ... on PRISMIC__FileLink {
                 _linkType


### PR DESCRIPTION
As per @darthvadur's suggestion, I'm using a `<video/>` to serve the mp4. The video file is 4.4 MB which still might be considered large, but the gif was 11MB so this is a substantial improvement.